### PR TITLE
add age match question and filtering

### DIFF
--- a/app/services/cat_matcher.rb
+++ b/app/services/cat_matcher.rb
@@ -23,7 +23,21 @@ class CatMatcher
 
   def matching_cat? cat
     tags = cat['tags'].map(&:downcase)
-    age = cat['age'].downcase
+
+    # Match on age
+    matched_age = matching_ages.include? cat['age']
+
+    # Get the intersection of tags and matching keywords.
+    # If there are matched keywords, this is a potential match.
+    matched_tags = tags & matching_keywords
+    match_found = matched_tags.length > 0
+
+    # Get the intersection of tags and exclusion keywords.
+    # If there are matched exclusions, this cannot be a match.
+    excluded_tags = tags & exclusion_keywords
+    exclusion_found = excluded_tags.length > 0
+
+    # Match with environment if attributes are present
     environment_matched = true
     if matching_environment.include? 'children'
       environment_matched &= cat['environment']['children']
@@ -35,9 +49,7 @@ class CatMatcher
       environment_matched &= cat['environment']['cats']
     end
 
-    puts tags
-
-    matching_keywords.include?(tags) && environment_matched == true #tags.include?(exclusion_keywords) == false && age.include?(matching_questions.to_s) == true
+    match_found && !exclusion_found && environment_matched && matched_age
   end
 
   def matching_questions
@@ -45,6 +57,11 @@ class CatMatcher
       .zip( answers )
       .select { |q,a| a == "yes" }
       .collect { |q,a| q }
+  end
+
+  def matching_ages
+    @matching_ages ||= answers
+      .select { |a| a != "yes" }
   end
 
   def matching_environment

--- a/app/services/quiz.rb
+++ b/app/services/quiz.rb
@@ -33,9 +33,9 @@ class Quiz
         question: 'Would your ideal cat like to follow you around?',
         keywords: ['friendly','social','loyal','curious']
       },
-        {
-        question:   'Would your ideal cat be independent and keep to themselves unless engaged?',
-        keywords:   ['solo','loner','independent','low key'],
+      {
+        question: 'Would your ideal cat be independent and keep to themselves unless engaged?',
+        keywords: ['solo','loner','independent','low key'],
         exclusions: ['outgoing','very social']
       },
       {
@@ -49,6 +49,10 @@ class Quiz
       {
         question: 'Do you have or want a dog/have dogs?',
         environment: ['dogs']
+      },
+      {
+        question: 'What age is your ideal cat?',
+        options: ['baby', 'young', 'adult', 'senior']
       }
     ]
   end

--- a/app/views/cats/quiz.html.erb
+++ b/app/views/cats/quiz.html.erb
@@ -5,27 +5,21 @@
       <%= label_tag("q#{index}", question[:question]) %>
     </div>
     <div>
-      <%= radio_button_tag("q#{index}", "yes", checked="checked") %>
-      <%= label_tag("q#{index}_yes", "Yes") %>
-      <%= radio_button_tag("q#{index}", "no") %>
-      <%= label_tag("q#{index}_no", "No") %>
+      <% if question[:options] %>
+        <% for option in question[:options] %>
+           <%= check_box_tag("q#{counter}_#{option}", "#{option}", checked="checked") %>
+           <%= label_tag("q#{counter}", "#{option}") %>
+        <% end %>
+      <% else %>
+          <%= radio_button_tag("q#{index}", "yes", checked="checked") %>
+          <%= label_tag("q#{index}_yes", "Yes") %>
+          <%= radio_button_tag("q#{index}", "no") %>
+          <%= label_tag("q#{index}_no", "No") %>
+      <% end %>
       <% counter = counter + 1 %>
-      </div>
-    <% end %>
+    </div>
+  <% end %>
 <div>
-  Is your ideal cat
-  <%= check_box_tag("q#{counter}", "baby", checked="checked") %>
-  <%= label_tag("q#{counter}_yes", "baby") %>
-  <% counter = counter + 1 %>
-  <%= check_box_tag("q#{counter}", "young", checked="checked") %>
-  <%= label_tag("q#{counter}_yes", "young") %>
-  <% counter = counter + 1 %>
-  <%= check_box_tag("q#{counter}", "adult", checked="checked") %>
-  <%= label_tag("q#{counter}_yes", "adult") %>
-  <% counter = counter + 1 %>
-  <%= check_box_tag("q#{counter}", "senior", checked="checked") %>
-  <%= label_tag("q#{counter}_yes", "senior") %>
-  </div>
   <div>
     <%= submit_tag("Find Cats") %>
   </div>


### PR DESCRIPTION
This pr does the following:
- adds a question to the quiz
- filters results based on quiz input

This is quick and dirty and should include a stricter check on the answers when setting `matching_ages`